### PR TITLE
Split out the search in navigate

### DIFF
--- a/ui/src/components/EuiCustomLink.jsx
+++ b/ui/src/components/EuiCustomLink.jsx
@@ -34,8 +34,16 @@ export default function EuiCustomLink({ to, ...rest }) {
     // Prevent regular link behavior, which causes a browser refresh.
     event.preventDefault();
 
+    // As of a few versions ago, react navigate expects search terms to be separate
+    const searchIdentifierIdx = to.indexOf('?')
+    const search = to.substring(searchIdentifierIdx + 1);
+    const pathTo = to.subscring(0, searchIdentifierIdx);
+
     // Push the route to the history.
-    navigate(to);
+    navigate({
+      pathname: pathTo,
+      search: search
+    });
   }
 
   // Generate the correct link href (with basename accounted for)

--- a/ui/src/components/EuiCustomLink.jsx
+++ b/ui/src/components/EuiCustomLink.jsx
@@ -34,15 +34,11 @@ export default function EuiCustomLink({ to, ...rest }) {
     // Prevent regular link behavior, which causes a browser refresh.
     event.preventDefault();
 
-    // As of a few versions ago, react navigate expects search terms to be separate
-    const searchIdentifierIdx = to.indexOf('?')
-    const search = to.substring(searchIdentifierIdx + 1);
-    const pathTo = to.subscring(0, searchIdentifierIdx);
-
     // Push the route to the history.
+    const returnToUrl = new URL(to, window.location.origin);
     navigate({
-      pathname: pathTo,
-      search: search
+        pathname: returnToUrl.pathname,
+        search: returnToUrl.searchParams.toString()
     });
   }
 


### PR DESCRIPTION
Attempting to solve

```
Error: Cannot include a '?' character in a manually specified `to.pathname` field [{"pathname":"/p/discord_ai_dev/feature-view?tags=team%3ADATA_ENGINEERING"}].  Please separate it out to the `to.search` field. Alternatively you may provide the full path as a string in <Link to="..."> and the router will parse it for you.
    at invariant (http://localhost:3000/static/js/bundle.js:75612:11)
    at resolveTo (http://localhost:3000/static/js/bundle.js:76324:5)
    at http://localhost:3000/static/js/bundle.js:138352:119
    at mountMemo (http://localhost:3000/static/js/bundle.js:119006:23)
    at Object.useMemo (http://localhost:3000/static/js/bundle.js:119391:20)
    at Object.useMemo (http://localhost:3000/static/js/bundle.js:145489:25)
    at useResolvedPath (http://localhost:3000/static/js/bundle.js:138352:45)
    at useHref (http://localhost:3000/static/js/bundle.js:138141:7)
    at EuiCustomLink (http://localhost:3000/static/js/bundle.js:36662:71)
    at renderWithHooks (http://localhost:3000/static/js/bundle.js:118234:22)
```